### PR TITLE
Fixed classes/servers.php query not working in multiserver installations

### DIFF
--- a/includes/classes/servers.php
+++ b/includes/classes/servers.php
@@ -50,7 +50,7 @@ class Servers
                                       s.netid = n.id 
                                     JOIN network AS p ON 
                                       n.parentid = p.id 
-                                      OR n.parentid = '0' 
+                                      OR (n.parentid = '0' and n.id=p.id)
                                     LEFT JOIN users AS u ON 
                                       s.userid = u.id 
                                     LEFT JOIN default_games AS d ON 


### PR DESCRIPTION
This is a reopen of #19

Issue is still present.

In a multi network server environment, gpx will send restart, stop, and maybe other server operations always to the first network server.
So gameservers on remote servers wich are not the first remote server, cannot be started or stopped.

This patch fixes that bug. Please, consider it.
Thank you.
