### PR TITLE
[Beta] solution to altered passwords during installation

### DIFF
--- a/install/install_actions.php
+++ b/install/install_actions.php
@@ -25,14 +25,14 @@ if($url_action == 'start')
     
     #####################################################################################
     
-    $url_language     = $_POST['language'];
-    $url_db_host      = $_POST['db_host'];
-    $url_db_name      = $_POST['db_name'];
-    $url_db_user      = $_POST['db_user'];
-    $url_db_pass      = $_POST['db_pass'];
-    $url_admin_user   = $_POST['admin_user'];
-    $url_admin_pass   = $_POST['admin_pass'];
-    $url_admin_email  = $_POST['admin_email'];
+    $url_language     = urldecode($_POST['language']);
+    $url_db_host      = urldecode($_POST['db_host']);
+    $url_db_name      = urldecode($_POST['db_name']);
+    $url_db_user      = urldecode($_POST['db_user']);
+    $url_db_pass      = urldecode($_POST['db_pass']);
+    $url_admin_user   = urldecode($_POST['admin_user']);
+    $url_admin_pass   = urldecode($_POST['admin_pass']);
+    $url_admin_email  = urldecode($_POST['admin_email']);
     
     // Test DB Connection
     @mysql_connect($url_db_host, $url_db_user, $url_db_pass) or die('Failed to connect to the database ('.mysql_error().').  Check your settings and try again.');

--- a/scripts/internal/install.js
+++ b/scripts/internal/install.js
@@ -9,6 +9,15 @@ function install_start()
     var adminPass   = $('#admin_pass').val();
     var adminPass2  = $('#admin_pass2').val();
     
+    dbHost = encodeURIComponent(dbHost);
+    dbName = encodeURIComponent(dbName);
+    dbUser = encodeURIComponent(dbUser);
+    dbPass = encodeURIComponent(dbPass);
+    adminUser = encodeURIComponent(adminUser);
+    adminEmail = encodeURIComponent(adminEmail);
+    adminPass = encodeURIComponent(adminPass);
+    adminPass2 = encodeURIComponent(adminPass2);
+    
     if(dbHost == "") { infobox('i','You left a field blank!'); $('#db_host').focus(); return false; }
     else if(dbName == "") { infobox('i','You left a field blank!'); $('#db_name').focus(); return false; }
     else if(dbUser == "") { infobox('i','You left a field blank!'); $('#db_user').focus(); return false; }


### PR DESCRIPTION
Passwords containing symbols like '%' where altered without notifying the user resulting in error messages saying the password is wrong while trying to connect to a MySQL database despite knowing its' right. My guess is that the ajax function automatically encodes/decodes the data in it's post request making a password like: 'abc%123' become: 'abc3' while the php function didn't perform any attempt to restore the original password.

(This is not tested) but it shows the concept and the cause of this issue.